### PR TITLE
feat: rework anchor worker scaling algorithm

### DIFF
--- a/ci/cmd/deploy/main.go
+++ b/ci/cmd/deploy/main.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -38,17 +36,11 @@ func main() {
 }
 
 func createJob(ctx context.Context) error {
-	newJob := map[string]interface{}{
-		"id":    uuid.New().String(),
-		"ts":    time.Now(),
-		"stage": models.DefaultJobState,
-		"type":  models.JobType_Deploy,
-		"params": map[string]string{
-			"component": models.DeployComponent,
-			"sha":       "latest",
-			"shaTag":    os.Getenv("SHA_TAG"),
-		},
-	}
+	newJob := models.NewJob(models.JobType_Deploy, map[string]interface{}{
+		"component": models.DeployComponent,
+		"sha":       "latest",
+		"shaTag":    os.Getenv("SHA_TAG"),
+	})
 	// Marshal the CD Manager job into DynamoDB-JSON, which is different from regular JSON and requires data types to be
 	// specified explicitly. The time encode function ensures that the timestamp has millisecond-resolution, which is
 	// what the CD Manager expects.

--- a/common/aws/ddb/state.go
+++ b/common/aws/ddb/state.go
@@ -260,8 +260,8 @@ func (sdb *StateDatabase) UpdateTip(ctx context.Context, newTip *models.StreamTi
 				oldTip,
 				func(options *attributevalue.DecoderOptions) {
 					options.DecodeTime = attributevalue.DecodeTimeAttributes{
-						S: sdb.tsDecode,
-						N: sdb.tsDecode,
+						S: tsDecode,
+						N: tsDecode,
 					}
 				}); err != nil {
 				log.Printf("updateTip: error unmarshaling old tip: %v", err)
@@ -276,12 +276,4 @@ func (sdb *StateDatabase) UpdateTip(ctx context.Context, newTip *models.StreamTi
 		// We wrote a new tip but did not have an old tip to return
 		return true, nil, nil
 	}
-}
-
-func (sdb *StateDatabase) tsDecode(ts string) (time.Time, error) {
-	msec, err := strconv.ParseInt(ts, 10, 64)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.UnixMilli(msec), nil
 }

--- a/common/aws/ddb/utils.go
+++ b/common/aws/ddb/utils.go
@@ -3,6 +3,7 @@ package ddb
 import (
 	"context"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -44,4 +45,12 @@ func tableExists(ctx context.Context, client *dynamodb.Client, table string) (bo
 	} else {
 		return output.Table.TableStatus == types.TableStatusActive, nil
 	}
+}
+
+func tsDecode(ts string) (time.Time, error) {
+	msec, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.UnixMilli(msec), nil
 }

--- a/models/job.go
+++ b/models/job.go
@@ -1,28 +1,46 @@
 package models
 
-const DefaultJobState = "queued"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
 const DeployComponent = "casv5"
 const WorkerVersion = "5"
 
-const (
-	JobType_Deploy = "deploy"
-	JobType_Anchor = "anchor"
-)
+type JobType string
 
 const (
-	JobParam_Id        = "id"
-	JobParam_Ts        = "ts"
-	JobParam_Stage     = "stage"
-	JobParam_Type      = "type"
-	JobParam_Params    = "params"
-	JobParam_Version   = "version"
-	JobParam_Overrides = "overrides"
+	JobType_Deploy JobType = "deploy"
+	JobType_Anchor JobType = "anchor"
 )
 
-// These need to match the Anchor Worker environment variable names
+type JobStage string
+
 const (
-	AnchorOverrides_UseQueueBatches = "USE_QUEUE_BATCHES"
-	AnchorOverrides_ContractAddress = "ETH_CONTRACT_ADDRESS"
-	AnchorOverrides_BatchQueueUrl   = "SQS_BATCH_QUEUE_URL"
-	AnchorOverrides_FailureQueueUrl = "SQS_FAILURE_QUEUE_URL"
+	JobStage_Queued    JobStage = "queued"
+	JobStage_Waiting   JobStage = "waiting"
+	JobStage_Failed    JobStage = "failed"
+	JobStage_Completed JobStage = "completed"
 )
+
+const JobParam_Version = "version"
+
+type JobState struct {
+	Stage  JobStage               `dynamodbav:"stage"`
+	Ts     time.Time              `dynamodbav:"ts"`
+	Id     string                 `dynamodbav:"id"`
+	Type   JobType                `dynamodbav:"type"`
+	Params map[string]interface{} `dynamodbav:"params"`
+}
+
+func NewJob(jobType JobType, params map[string]interface{}) JobState {
+	return JobState{
+		Stage:  JobStage_Queued,
+		Ts:     time.Time{},
+		Id:     uuid.New().String(),
+		Type:   jobType,
+		Params: params,
+	}
+}

--- a/models/services.go
+++ b/models/services.go
@@ -20,7 +20,8 @@ type StateRepository interface {
 }
 
 type JobRepository interface {
-	CreateJob(ctx context.Context) error
+	CreateJob(ctx context.Context) (string, error)
+	QueryJob(ctx context.Context, id string) (*JobState, error)
 }
 
 type QueuePublisher interface {

--- a/services/test_helpers.go
+++ b/services/test_helpers.go
@@ -115,8 +115,8 @@ func (m *MockJobRepository) CreateJob(_ context.Context) (string, error) {
 }
 
 func (m *MockJobRepository) QueryJob(_ context.Context, id string) (*models.JobState, error) {
-	if _, found := m.jobStore[id]; found {
-		return &models.JobState{}, nil
+	if jobState, found := m.jobStore[id]; found {
+		return jobState, nil
 	}
 	return nil, fmt.Errorf("job %s not found", id)
 }

--- a/services/worker.go
+++ b/services/worker.go
@@ -16,6 +16,7 @@ type WorkerService struct {
 	jobDb            models.JobRepository
 	monitorTick      time.Duration
 	maxAnchorWorkers int
+	anchorJobs       map[string]*models.JobState
 }
 
 func NewWorkerService(batchMonitor models.QueueMonitor, jobDb models.JobRepository) *WorkerService {
@@ -31,7 +32,7 @@ func NewWorkerService(batchMonitor models.QueueMonitor, jobDb models.JobReposito
 			maxAnchorWorkers = parsedMaxAnchorWorkers
 		}
 	}
-	return &WorkerService{batchMonitor, jobDb, batchMonitorTick, maxAnchorWorkers}
+	return &WorkerService{batchMonitor, jobDb, batchMonitorTick, maxAnchorWorkers, make(map[string]*models.JobState)}
 }
 
 func (w WorkerService) Run(ctx context.Context) {
@@ -50,30 +51,58 @@ func (w WorkerService) Run(ctx context.Context) {
 }
 
 func (w WorkerService) launch(ctx context.Context) (int, error) {
-	if numBatchesUnprocessed, numBatchesInFlight, err := w.batchMonitor.GetQueueUtilization(ctx); err != nil {
+	if numJobsRequired, numExistingJobs, err := w.calculateScaling(ctx); err != nil {
 		return 0, err
 	} else {
-		// The number of unprocessed batches can be used to determine the ingress load on the anchoring system.
-		//
-		// The number of batches in flight can be used to observe the current state of the system. Each anchor worker
-		// will process a single batch at a time, even if it continues to poll the queue for more batches as it gets
-		// done with previous ones. This means that we can infer the number of running workers by looking at the number
-		// of batches in flight.
 		numJobsAllowed := 0
 		if w.maxAnchorWorkers == -1 {
 			// We can create as many workers as needed to service unprocessed batches
-			numJobsAllowed = numBatchesUnprocessed
-		} else if numBatchesInFlight < w.maxAnchorWorkers {
-			// We can create workers upto the maximum allowed minus the number already running
-			numJobsAllowed = w.maxAnchorWorkers - numBatchesInFlight
+			numJobsAllowed = numJobsRequired
+		} else if numExistingJobs < w.maxAnchorWorkers {
+			// We can create workers upto the maximum allowed minus the number of jobs already created
+			numJobsAllowed = w.maxAnchorWorkers - numExistingJobs
 		}
-		numJobsToCreate := int(math.Min(float64(numJobsAllowed), float64(numBatchesUnprocessed)))
+		numJobsToCreate := int(math.Min(float64(numJobsAllowed), float64(numJobsRequired)))
 		var numJobsCreated int
 		for numJobsCreated = 0; numJobsCreated < numJobsToCreate; numJobsCreated++ {
-			if err = w.jobDb.CreateJob(ctx); err != nil {
+			if jobId, err := w.jobDb.CreateJob(ctx); err != nil {
 				break
+			} else {
+				w.anchorJobs[jobId] = nil
 			}
 		}
 		return numJobsCreated, err
+	}
+}
+
+func (w WorkerService) calculateScaling(ctx context.Context) (int, int, error) {
+	// Clean up finished jobs
+	for jobId, _ := range w.anchorJobs {
+		if jobState, err := w.jobDb.QueryJob(ctx, jobId); err != nil {
+			return 0, 0, err
+		} else if (jobState.Stage == models.JobStage_Completed) || (jobState.Stage == models.JobStage_Failed) {
+			// Clean out finished jobs - "completed" and "failed" are the only possible terminal stages for anchor jobs
+			delete(w.anchorJobs, jobId)
+		} else {
+			w.anchorJobs[jobId] = jobState
+		}
+	}
+	// This includes jobs that have been created but not yet started (perhaps due to a deployment in progress). If there
+	// is a problem starting jobs on the CD manager or anchor worker side, we won't keep creating new jobs unless we
+	// have newer batches to process.
+	//
+	// Alerting on the size of the batch queue backlog will inform us if jobs haven't been making progress while batches
+	// have continued to be created.
+	numExistingJobs := len(w.anchorJobs)
+	if numBatchesUnprocessed, _, err := w.batchMonitor.GetQueueUtilization(ctx); err != nil {
+		return 0, 0, err
+	} else {
+		// The number of active workers can be used to observe the current throughput of the system. Each anchor worker
+		// will process a single batch at a time, even if it continues to poll the queue for more batches as it gets
+		// done with earlier ones.
+		//
+		// The number of overflow batches (i.e. the surplus over the number of active workers) can be used to determine
+		// the additional ingress load on the anchoring system and thus the number of new workers required.
+		return int(math.Max(float64(numBatchesUnprocessed-numExistingJobs), 0)), numExistingJobs, nil
 	}
 }

--- a/services/worker.go
+++ b/services/worker.go
@@ -71,6 +71,7 @@ func (w WorkerService) launch(ctx context.Context) (int, error) {
 				w.anchorJobs[jobId] = nil
 			}
 		}
+		log.Printf("worker: numJobsRequired=%d, anchorJobs=%v", numJobsRequired, w.anchorJobs)
 		return numJobsCreated, err
 	}
 }

--- a/services/worker_test.go
+++ b/services/worker_test.go
@@ -60,7 +60,7 @@ func TestRun(t *testing.T) {
 			newJobs:    3,
 		},
 		"resume creating jobs if existing job finishes": {
-			monitor:      &MockQueueMonitor{3, 1},
+			monitor:      &MockQueueMonitor{3, 0},
 			jobDb:        &MockJobRepository{failCount: 0},
 			maxWorkers:   2,
 			inflightJobs: 2,
@@ -92,9 +92,11 @@ func TestRun(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
 			workerService.Run(ctx)
 			cancel()
-			numJobsRemaining := test.inflightJobs + test.newJobs - test.finishedJobs
-			if len(test.jobDb.jobStore) != numJobsRemaining {
-				t.Errorf("incorrect number %d of remaining jobs, expected %d", len(test.jobDb.jobStore), numJobsRemaining)
+			// Since jobs are not deleted from the database, the total number of jobs will be the number of jobs created
+			// over both calls to `WorkerService.Run`.
+			totalNumJobs := test.inflightJobs + test.newJobs
+			if len(test.jobDb.jobStore) != totalNumJobs {
+				t.Errorf("incorrect number %d of remaining jobs, expected %d", len(test.jobDb.jobStore), totalNumJobs)
 			}
 		})
 	}

--- a/services/worker_test.go
+++ b/services/worker_test.go
@@ -9,64 +9,93 @@ import (
 
 func TestRun(t *testing.T) {
 	tests := map[string]struct {
-		monitor         *MockQueueMonitor
-		jobDb           *MockJobRepository
-		maxWorkers      int
-		expectedWorkers int
+		monitor      *MockQueueMonitor
+		jobDb        *MockJobRepository
+		maxWorkers   int
+		inflightJobs int
+		finishedJobs int
+		newJobs      int
 	}{
 		"create as many jobs as unprocessed batches": {
-			monitor:         &MockQueueMonitor{5, 0, &MockJobRepository{failCount: 0}, 0},
-			maxWorkers:      -1,
-			expectedWorkers: 5,
+			monitor:    &MockQueueMonitor{5, 0},
+			jobDb:      &MockJobRepository{failCount: 0},
+			maxWorkers: -1,
+			newJobs:    5,
 		},
 		"create jobs upto configured max": {
-			monitor:         &MockQueueMonitor{3, 0, &MockJobRepository{failCount: 0}, 0},
-			maxWorkers:      2,
-			expectedWorkers: 2,
+			monitor:    &MockQueueMonitor{3, 0},
+			jobDb:      &MockJobRepository{failCount: 0},
+			maxWorkers: 2,
+			newJobs:    2,
 		},
 		"do not create jobs if max already in flight": {
-			monitor:         &MockQueueMonitor{3, 2, &MockJobRepository{failCount: 0}, 0},
-			maxWorkers:      2,
-			expectedWorkers: 0,
+			monitor:      &MockQueueMonitor{3, 0},
+			jobDb:        &MockJobRepository{failCount: 0},
+			maxWorkers:   2,
+			inflightJobs: 2,
+			newJobs:      0,
 		},
 		"do not create jobs if no unprocessed batches": {
-			monitor:         &MockQueueMonitor{0, 0, &MockJobRepository{failCount: 0}, 0},
-			maxWorkers:      -1,
-			expectedWorkers: 0,
+			monitor:    &MockQueueMonitor{0, 0},
+			jobDb:      &MockJobRepository{failCount: 0},
+			maxWorkers: -1,
+			newJobs:    0,
 		},
 		"create only as many jobs as necessary": {
-			monitor:         &MockQueueMonitor{1, 0, &MockJobRepository{failCount: 0}, 0},
-			maxWorkers:      2,
-			expectedWorkers: 1,
+			monitor:    &MockQueueMonitor{1, 0},
+			jobDb:      &MockJobRepository{failCount: 0},
+			maxWorkers: 2,
+			newJobs:    1,
 		},
 		"continue creating jobs after db error": {
-			monitor:         &MockQueueMonitor{3, 0, &MockJobRepository{failCount: 1}, 0},
-			maxWorkers:      3,
-			expectedWorkers: 3,
+			monitor:    &MockQueueMonitor{3, 0},
+			jobDb:      &MockJobRepository{failCount: 1},
+			maxWorkers: 3,
+			newJobs:    3,
 		},
 		"continue creating jobs after queue error": {
-			monitor:         &MockQueueMonitor{3, 0, &MockJobRepository{failCount: 0}, 1},
-			maxWorkers:      3,
-			expectedWorkers: 3,
+			monitor:    &MockQueueMonitor{3, 1},
+			jobDb:      &MockJobRepository{failCount: 0},
+			maxWorkers: 3,
+			newJobs:    3,
+		},
+		"resume creating jobs if existing job finishes": {
+			monitor:      &MockQueueMonitor{3, 1},
+			jobDb:        &MockJobRepository{failCount: 0},
+			maxWorkers:   2,
+			inflightJobs: 2,
+			finishedJobs: 1,
+			newJobs:      1,
 		},
 	}
 	t.Setenv("ANCHOR_BATCH_MONITOR_TICK", "100ms")
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv("MAX_ANCHOR_WORKERS", strconv.FormatInt(int64(test.maxWorkers), 10))
-			test.jobDb = test.monitor.jobDb
-			t.Logf("start: unprocessed=%d, inflight=%d, max=%d", test.monitor.unprocessed, test.monitor.inFlight, test.maxWorkers)
 			workerService := NewWorkerService(test.monitor, test.jobDb)
+			if test.inflightJobs > 0 {
+				// Pre-run the service so that it creates jobs in flight
+				ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
+				workerService.Run(ctx)
+				cancel()
+
+				if len(test.jobDb.jobStore) != test.inflightJobs {
+					t.Errorf("incorrect number %d of jobs, expected %d", len(test.jobDb.jobStore), test.inflightJobs)
+				}
+			}
+			if test.finishedJobs > 0 {
+				// Complete some jobs
+				test.jobDb.finishJobs(test.finishedJobs)
+			}
 			// Cancel the context after at least 3 iterations of the ticker so that we can test how the service behaves
 			// over time, especially when there are errors.
 			ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
 			workerService.Run(ctx)
 			cancel()
-			if len(test.jobDb.jobStore) != test.expectedWorkers {
-				t.Errorf("incorrect number %d of workers created, expected %d", len(test.jobDb.jobStore), test.expectedWorkers)
+			numJobsRemaining := test.inflightJobs + test.newJobs - test.finishedJobs
+			if len(test.jobDb.jobStore) != numJobsRemaining {
+				t.Errorf("incorrect number %d of remaining jobs, expected %d", len(test.jobDb.jobStore), numJobsRemaining)
 			}
-			numProcessed, numInFlight, _ := test.monitor.GetQueueUtilization(nil)
-			t.Logf("end: unprocessed=%d, inflight=%d, created=%d", numProcessed, numInFlight, len(test.jobDb.jobStore))
 		})
 	}
 }


### PR DESCRIPTION
Instead of using just the number of batches in flight, this code now uses actual CD manager jobs and states.

This prevents new jobs from being spuriously created if, for any reason, anchor workers could not be started. This could happen if there's a deployment in progress, there's a bug in the CD manager starting anchor workers, there's a bug in the anchor worker that causes it to crash, etc.