### PR TITLE
Flag for hostname changed to --server.host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
       - --miner.blockTime=5
       - --mnemonic='move sense much taxi wave hurry recall stairs thank brother nut woman'
       - --networkId=5777
-      - --hostname=0.0.0.0
+      - --server.host=0.0.0.0
       - -l=80000000
     networks:
       - internal


### PR DESCRIPTION
Small bug fix, ganache was not coming up with an error:
```
ganache            | Unknown argument: hostname
```

Updated to match the flag from --help and it started up ok.