### PR TITLE
chores: use url for ipfs

### DIFF
--- a/common/ipfs/api.go
+++ b/common/ipfs/api.go
@@ -87,7 +87,7 @@ func (i *IpfsApi) processIpfsTask(ctx context.Context, task any) error {
 
 func (i *IpfsApi) limiterRunFunction(ctx context.Context, task any) (any, error) {
 	if err := i.processIpfsTask(ctx, task); err != nil {
-		i.logger.Errorf("IPFS error for task %v on ipfs %v", task, i.multiAddressStr)
+		i.logger.Errorf("IPFS error for task %v on ipfs %v: %w", task, i.multiAddressStr, err)
 		i.metricService.Count(ctx, models.MetricName_IpfsError, 1)
 		// TODO: if we get many timeout errors, adjust the limiter values
 		// TODO: restart the ipfs instance if there are too many errors and mark unavailable

--- a/services/ipfs.go
+++ b/services/ipfs.go
@@ -31,7 +31,7 @@ func NewIpfsService(logger models.Logger, metricService models.MetricService) *I
 	}
 
 	ipfsStrAddresses := []string{"/ip4/127.0.0.1/tcp/5011"}
-	if configIpfsStrAddresses, found := os.LookupEnv("IPFS_MULTIADDRESSES"); found {
+	if configIpfsStrAddresses, found := os.LookupEnv("IPFS_ADDRESSES"); found {
 		parsedIpfsStrAddress := strings.Split(configIpfsStrAddresses, " ")
 		ipfsStrAddresses = parsedIpfsStrAddress
 	}


### PR DESCRIPTION
In order to use multiaddresses we would need to know the peer id of the ipfs node ahead of time. 

In keramik this is hard to do because the peers config map is populated at the end of the reconcile pass of the network. I am not sure how to apply a stateful set, then wait until the service comes up so I can get the peer id, and then use that value to create the other stateful sets. I could also deterministically generate the peer id. But then keramik is not configured to allow that yet. 

So i'm attempting this again. Sorry for the env var name change. Also feel free to reject =)  